### PR TITLE
Add second argument to functions used as arguments of BVP2Dsym, BVP2D…

### DIFF
--- a/doc/Demos/LaplaceCylindrical.m
+++ b/doc/Demos/LaplaceCylindrical.m
@@ -2,10 +2,10 @@ FEMmesh = CreateMeshRect(linspace(0,2,20),linspace(-1,2,30),-1,-1,-2,-2);
 %%FEMMesh = CreateMeshTriangle('test',[0 -1 -1; 2 -1 -2; 2 2 -1; 0 2 -2],0.1); 
 FEMmesh = MeshUpgrade(FEMmesh, 'quadratic');  %% uncomment to use quadratic elements
 
-function res = f(rz)   res = rz(:,1)*2.*rz(:,2); endfunction
-function res = b0(rz)  res = 10*rz(:,1);         endfunction
-function res = a(rz)   res = rz(:,1);            endfunction
-function res = g2(rz)  res = -1*rz(:,1)/2;       endfunction
+function res = f(rz,m)   res = rz(:,1)*2.*rz(:,2); endfunction
+function res = b0(rz,m)  res = 10*rz(:,1);         endfunction
+function res = a(rz,m)   res = rz(:,1);            endfunction
+function res = g2(rz,m)  res = -1*rz(:,1)/2;       endfunction
 
 u = BVP2Dsym(FEMmesh,'a','b0','f',0,'g2',0);
 

--- a/doc/Demos/TestConvergence.m
+++ b/doc/Demos/TestConvergence.m
@@ -1,7 +1,7 @@
 clear *
-  function res = u_exact(xy)  res =   sin(xy(:,1)).*sin(xy(:,2));   endfunction
-  function res = f(xy)        res = 2*sin(xy(:,1)).*sin(xy(:,2));   endfunction
-  function res = u_y(xy)      res =   sin(xy(:,1)).*cos(xy(:,2));   endfunction
+  function res = u_exact(xy,a) res =   sin(xy(:,1)).*sin(xy(:,2));   endfunction
+  function res = f(xy,a)       res = 2*sin(xy(:,1)).*sin(xy(:,2));   endfunction
+  function res = u_y(xy,a)     res =   sin(xy(:,1)).*cos(xy(:,2));   endfunction
 
 a = 1; b0 = 0;  gN2 = 0;
 N = 6;

--- a/doc/Examples/BesselSuperconvergence/BesselSuperconvergence.m
+++ b/doc/Examples/BesselSuperconvergence/BesselSuperconvergence.m
@@ -18,15 +18,15 @@ else
 endif
 
 
-function y = uSol(xy)
+function y = uSol(xy,m)
   y = besselj(0,sqrt(xy(:,1).^2+xy(:,2).^2));
 endfunction
 %% the Besselj(0,r) function is an eigenfunction with eigenvalue 1
-function y = LapuSol(xy)
+function y = LapuSol(xy,m)
   y = 2*besselj(0,sqrt(xy(:,1).^2+xy(:,2).^2));
 endfunction
 
-function y = aa(xy)
+function y = aa(xy,m)
   y = ones(length(xy),1);
 endfunction
 

--- a/doc/Examples/Capacitance/Capacitance.m
+++ b/doc/Examples/Capacitance/Capacitance.m
@@ -5,8 +5,8 @@ x = FEMmesh.nodes(:,1); y = FEMmesh.nodes(:,2);
 figure(1)
 FEMtrimesh(FEMmesh)
 
-function res = a(xy)     res = xy(:,1);      endfunction
-function res = Volt(xy)  res = xy(:,2)>0.1;  endfunction
+function res = a(xy,m)     res = xy(:,1);      endfunction
+function res = Volt(xy,m)  res = xy(:,2)>0.1;  endfunction
 
 u = BVP2Dsym(FEMmesh,'a',0,0,'Volt',0,0);
 figure(2)

--- a/doc/Examples/EIT/EITforward.m
+++ b/doc/Examples/EIT/EITforward.m
@@ -6,7 +6,7 @@ x = Rx*cos(alpha); y = Ry*sin(alpha);
 BC = -2*ones(size(x));
 my_angle = 120  %% select the configuration, use 60 or 120
 
-function res = sigma(xy)                 %% the conductivity
+function res = sigma(xy,m)               %% the conductivity
   x = xy(:,1); y = xy(:,2);
   res = ones(size(x));
   res((x+0.5).^2+y.^2<=0.25^2) *=  4 ;   %% heart on the left

--- a/doc/Examples/HeatDynamic/HeatDynamicCoefficient.m
+++ b/doc/Examples/HeatDynamic/HeatDynamicCoefficient.m
@@ -8,7 +8,7 @@ FEMmesh = MeshUpgrade(FEMmesh,'quadratic');
 figure(1); FEMtrimesh(FEMmesh);
            axis equal; xlabel('x'); ylabel('y')
 
-function res = a(xy)
+function res = a(xy,m)
   l = 0.5;
   res = ones(size(xy,1),1);
   res(find(abs(xy(:,1)-1-l/2)<l/2)) *= 1/6; 


### PR DESCRIPTION
…symMean, and IBVP2D

The functions, that are passed by name as strings to the functions BVP2Dsym, BVP2DsymMean, and IBVP2D, are further passed as arguments of FEMEquation, which calls them with two arguments.